### PR TITLE
Remove CODEOWNERS-file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-# global owner
-* @markusbaumeister
-
-/gap/modifying_simplicial_surfaces.g @jesselansdown


### PR DESCRIPTION
The CODEOWNERS-file blocks merging unless the owner accepts this. The recent change of responsibility (and two approving reviews) makes this unnecessary.