### PR TITLE
Split/Join Labels Documentation and some special cases

### DIFF
--- a/gap/PolygonalComplexes/modification.gd
+++ b/gap/PolygonalComplexes/modification.gd
@@ -166,6 +166,9 @@
 #! changed. Otherwise the old edge label is no longer used and will be
 #! replaced by the appropriate number of new labels. The new labels can be
 #! defined by the optional argument <A>newEdgeLabels</A>.
+#! Let <A>numFaces</A> be the number of incident faces from <A>edge</A>, i.e. the number of new edges.
+#! By default, the list <A>newEdgeLabels</A> is the list <A>[1..numFaces]</A>,
+#! which is shifted by the maximal edge label in each entry.
 #!
 #! For example consider the following triangular complex:
 #! <Alt Only="TikZ">
@@ -178,8 +181,10 @@
 #! simplicial surface (4 vertices, 5 edges, and 2 faces)
 #! gap> eye:=SplitEdge(closeEye,2);
 #! [ triangular complex (4 vertices, 6 edges, and 2 faces), [ 6, 7 ] ] 
-#! @EndExampleSession
-#! 
+#! @EndExampleSession 
+#! [ 6, 7 ] are the new edge labels, because the new edge labels are not given and 
+#! edge 2 is incident to two faces and the maximal edge label is 5.
+#!
 #! <Alt Only="TikZ">
 #!      \input{Image_Eye_Open.tex}
 #! </Alt>
@@ -212,6 +217,9 @@ DeclareOperation( "SplitEdgeNC", [IsPolygonalComplex, IsPosInt, IsList] );
 #! label will stay the same. Otherwise the old label will be removed and
 #! replaced by new labels. The new labels can be defined by the optional
 #! argument <A>newVertexLabels</A>.
+#! Let <A>numVert</A> be the number of new vertices that are necessary to split <A>vertex</A>.
+#! By default, the list <A>newEdgeLabels</A> is the list <A>[1..numVert]</A>, 
+#! which is shifted by the maximal vertex label in each entry.
 #!
 #! For example consider the following triangular complex:
 #! <Alt Only="TikZ">
@@ -225,6 +233,8 @@ DeclareOperation( "SplitEdgeNC", [IsPolygonalComplex, IsPosInt, IsList] );
 #! gap> splittedComplex:=SplitVertex(ramSurf,1);
 #! [ simplicial surface (8 vertices, 11 edges, and 5 faces), [ 13, 14 ] ]
 #! @EndExampleSession
+#! [ 13, 14 ] are the new vertex labels, because new vertex labels are not given 
+#! and vertex 1 has two elements in the umbrella partition and the maximal vertex label is 12.
 #! Splitting the vertex 1 in the complex divides the complex into two components:
 #! @BeginExampleSession
 #! gap> NumberOfConnectedComponents(splittedComplex[1]);
@@ -282,15 +292,18 @@ DeclareOperation( "SplitVertexNC", [IsPolygonalComplex, IsPosInt, IsList] );
 #!   \input{Image_SplitEdgePath.tex}
 #! </Alt>
 #! @BeginExampleSession
-#! gap> path:=VertexEdgePathByEdges(complex,[3,8]);
-#! | v1, E3, v3, E8, v6 |
+#! gap> path:=VertexEdgePathByEdges(complex,[3,8]);;
 #! @EndExampleSession
 #! Splitting the complex along this path leads to four one faces:
 #! @BeginExampleSession
-#! gap> splitted:=SplitVertexEdgePath(complex,path);;
+#! gap> splitted:=SplitVertexEdgePath(complex,path);
+#! [ simplicial surface (12 vertices, 12 edges, and 4 faces),
+#!   [ [ | v12, E13, v14 |, | v3, E8, v6 | ],
+#!     [ | v13, E14, v15 |, | v3, E8, v6 | ] ] ]
 #! gap> NumberOfConnectedComponents(splitted[1]);
 #! 4
 #! @EndExampleSession
+#! The second output shows in which two path the original path was splitted.
 #!
 #! The NC-versions do not check whether the given vertex-edge-paths match
 #! the given <A>complex</A>.
@@ -344,16 +357,19 @@ DeclareOperation( "SplitVertexEdgePathNC", [IsPolygonalComplex, IsVertexEdgePath
 #!   \input{Image_SplitEdgePath.tex}
 #! </Alt>
 #! @BeginExampleSession
-#! gap> path:=VertexEdgePathByEdges(complex,[3,8]);
-#! | v1, E3, v3, E8, v6 |
+#! gap> path:=VertexEdgePathByEdges(complex,[3,8]);;
 #! @EndExampleSession
 #! Splitting the complex along this path without the first and the last vertex leads
 #! to two components:
 #! @BeginExampleSession
-#! gap> splitted:=SplitEdgePath(complex,path);;
+#! gap> splitted:=SplitEdgePath(complex,path);
+#! [ triangular complex (10 vertices, 12 edges, and 4 faces),
+#!  [ [ | v10, E13, v6 |, | v3, E8, v6 | ],
+#!    [ | v11, E14, v6 |, | v3, E8, v6 | ] ] ]
 #! gap> NumberOfConnectedComponents(splitted[1]);
 #! 2
 #! @EndExampleSession
+#! The second output shows in which two path the original path was splitted.
 #!
 #! The NC-versions do not check whether the given vertex-edge-paths match
 #! the given <A>complex</A>.
@@ -675,8 +691,10 @@ DeclareOperation( "DisjointUnion", [IsPolygonalComplex, IsPolygonalComplex, IsIn
 #!      <K>fail</K> if the vertices are incident to a common face.
 #!
 #!      The optional argument <A>newVertexLabel</A> allows to set the
-#!      label of the new vertex. By default, an unused label will be
-#!      chosen.</Item>
+#!      label of the new vertex. By default, <A>newVertexLabel</A> is one 
+#!      higher than the maximal vertex label unless the vertices to be joined 
+#!      are equal or the length of <A>vertexList</A> is one. In these cases
+#!      the label does not change.</Item>
 #!   <Item>Combine two vertices <A>v1</A> and <A>v2</A> of two distinct
 #!      polygonal complexes <A>complex1</A> and <A>complex2</A>. This will
 #!      perform <K>DisjointUnion</K> (<Ref Subsect="DisjointUnion"/>) on
@@ -701,7 +719,7 @@ DeclareOperation( "DisjointUnion", [IsPolygonalComplex, IsPolygonalComplex, IsIn
 #! gap> octJoin = fail;
 #! false
 #! @EndExampleSession
-#! This combines the vertices 1 and 6 into a new one, which becomes a 
+#! This combines the vertices 1 and 6 into a new vertex with label 7, which becomes a 
 #! ramified vertex (<Ref Subsect="RamifiedVertices"/>).
 #! @BeginExampleSession
 #! gap> octJoin[2];
@@ -782,7 +800,10 @@ DeclareOperation( "JoinVerticesNC", [IsPolygonalComplex, IsPosInt, IsPolygonalCo
 #! @Description
 #! Combine two edges <A>e1</A> and <A>e2</A> of a polygonal complex into one
 #! edge, whose new label can be given by the optional argument 
-#! <A>newEdgeLabel</A> (otherwise a default label is chosen). The edges have 
+#! <A>newEdgeLabel</A>. By default, <A>newEdgeLabel</A> is one higher 
+#! than the maximal edge label unless the edges to be joined
+#! are equal or the length of <A>edgeList</A> is one. In these cases
+#! the label does not change. The edges have 
 #! to have had the same incident vertices.
 #! 
 #! This method returns a pair, where the first entry is the modified polygonal
@@ -813,6 +834,7 @@ DeclareOperation( "JoinVerticesNC", [IsPolygonalComplex, IsPosInt, IsPolygonalCo
 #! gap> closeEye[2];
 #! 7
 #! @EndExampleSession
+#! Since 6 is the maximal edge label, 7 is the label of the new edge.
 #! <Alt Only="TikZ">
 #!     \input{Image_Eye_OpenClosed.tex}
 #! </Alt>
@@ -841,7 +863,10 @@ DeclareOperation("JoinEdgesNC", [IsPolygonalComplex, IsList, IsPosInt]);
 #! @Description
 #! Combine two faces <A>F1</A> and <A>F2</A> of a polygonal complex into one
 #! face, whose new label can be given by the optional argument 
-#! <A>newFaceLabel</A> (otherwise a default label is chosen). The faces have 
+#! <A>newFaceLabel</A>. By default, <A>newFaceLabel</A> is one higher
+#! than the maximal face label unless the faces to be joined
+#! are equal or the length of <A>faceList</A> is one. In these cases
+#! the label does not change. The faces have 
 #! to have had the same incident edges.
 #! 
 #! This method returns a pair, where the first entry is the modified polygonal
@@ -852,7 +877,8 @@ DeclareOperation("JoinEdgesNC", [IsPolygonalComplex, IsList, IsPosInt]);
 #! gap> JoinFaces(JanusHead(),1,2);
 #! [ simplicial surface (3 vertices, 3 edges, and 1 faces), 3 ]
 #! @EndExampleSession
-#! The resulting surface is the one-face.
+#! The resulting surface is the one-face. Since 2 is the maximal face label,
+#! 3 is the label of the new face.
 #!
 #! The NC-versions do not check whether the given faces are distinct faces
 #! with the same incident edges of <A>complex</A> and whether the new face label is

--- a/gap/PolygonalComplexes/modification.gi
+++ b/gap/PolygonalComplexes/modification.gi
@@ -970,7 +970,14 @@ RedispatchOnCondition( JoinVerticesNC, true,
 InstallOtherMethod( JoinEdges, "for a polygonal complex and two edges",
     [IsPolygonalComplex, IsPosInt, IsPosInt],
     function(complex, e1, e2)
-        return JoinEdges(complex, e1, e2, Edges(complex)[NumberOfEdges(complex)]+1);
+        local label;
+		
+	if e1 = e2 then
+		label := e1;
+	else
+		label := Last(Edges(complex))+1;
+	fi;
+        return JoinEdges(complex, e1, e2, label);
     end
 );
 RedispatchOnCondition( JoinEdges, true, 
@@ -979,7 +986,14 @@ RedispatchOnCondition( JoinEdges, true,
 InstallOtherMethod( JoinEdgesNC, "for a polygonal complex and two edges",
     [IsPolygonalComplex, IsPosInt, IsPosInt],
     function(complex, e1, e2)
-        return JoinEdgesNC(complex, e1, e2, Edges(complex)[NumberOfEdges(complex)]+1);
+        local label;
+		
+	if e1 = e2 then
+		label := e1;
+	else
+		label := Last(Edges(complex))+1;
+	fi;
+        return JoinEdgesNC(complex, e1, e2, label);
     end
 );
 RedispatchOnCondition( JoinEdgesNC, true, 
@@ -992,8 +1006,8 @@ InstallMethod( JoinEdges,
     function(complex, e1, e2, newEdgeLabel)
         __SIMPLICIAL_CheckEdge(complex, e1, "JoinEdges");
         __SIMPLICIAL_CheckEdge(complex, e2, "JoinEdges");
-        if e1 = e2 then
-            Error(Concatenation("JoinEdges: Given edges are identical: ", String(e1), "."));
+        if e1 = e2 and e1 = newEdgeLabel then
+            return [complex, newEdgeLabel];
         fi;
         if newEdgeLabel <> e1 and newEdgeLabel <> e2 and newEdgeLabel in Edges(complex) then
             Error(Concatenation("JoinEdges: Given new edge label ", 
@@ -1064,7 +1078,15 @@ InstallOtherMethod(JoinEdges,
 	"for a polygonal complex and a list",
 	[IsPolygonalComplex,IsList],
 	function(complex,edgeList)
-		return JoinEdges(complex,edgeList,Last(Edges(complex))+1);
+		local edgeSet, label;
+		
+		edgeSet := Set(edgeList);
+		if Length(edgeSet) = 1 then
+			label := edgeSet[1];
+		else
+			label := Last(Edges(complex))+1;
+		fi;
+		return JoinEdges(complex,edgeList,label);
 	end
 );
 RedispatchOnCondition( JoinEdges, true, 
@@ -1075,7 +1097,15 @@ InstallOtherMethod(JoinEdgesNC,
 	"for a polygonal complex and a list",
 	[IsPolygonalComplex,IsList],
 	function(complex,edgeList)
-		return JoinEdgesNC(complex,edgeList,Last(Edges(complex))+1);
+		local edgeSet, label;
+		
+		edgeSet := Set(edgeList);
+		if Length(edgeSet) = 1 then
+			label := edgeSet[1];
+		else
+			label := Last(Edges(complex))+1;
+		fi;
+		return JoinEdgesNC(complex,edgeList,label);
 	end
 );
 RedispatchOnCondition( JoinEdgesNC, true, 
@@ -1131,7 +1161,14 @@ RedispatchOnCondition( JoinEdgesNC, true,
 InstallOtherMethod( JoinFaces, "for a polygonal complex and two faces",
     [IsPolygonalComplex, IsPosInt, IsPosInt],
     function(complex, F1, F2)
-        return JoinFaces(complex, F1, F2, Faces(complex)[NumberOfFaces(complex)]+1);
+	local label;
+		
+	if F1 = F2 then
+		label := F1;
+	else
+		label := Last(Faces(complex))+1;
+	fi;
+        return JoinFaces(complex, F1, F2, label);
     end
 );
 RedispatchOnCondition( JoinFaces, true, 
@@ -1141,7 +1178,14 @@ RedispatchOnCondition( JoinFaces, true,
 InstallOtherMethod( JoinFacesNC, "for a polygonal complex and two faces",
     [IsPolygonalComplex, IsPosInt, IsPosInt],
     function(complex, F1, F2)
-        return JoinFacesNC(complex, F1, F2, Faces(complex)[NumberOfFaces(complex)]+1);
+	local label;
+
+        if F1 = F2 then
+                label := F1;
+        else
+                label := Last(Faces(complex))+1;
+        fi;
+        return JoinFacesNC(complex, F1, F2, label);
     end
 );
 RedispatchOnCondition( JoinFacesNC, true, 
@@ -1152,24 +1196,24 @@ InstallMethod( JoinFaces,
     "for a polygonal complex, two faces and a new face label",
     [IsPolygonalComplex, IsPosInt, IsPosInt, IsPosInt],
 	function(complex, F1, F2, newFaceLabel)
-			__SIMPLICIAL_CheckFace(complex, F1, "JoinFaces");
-			__SIMPLICIAL_CheckFace(complex, F2, "JoinFaces");
-			if F1 = F2 then
-				Error(Concatenation("JoinFaces: Given faces are identical: ", String(F1), "."));
-			fi;
-			if newFaceLabel <> F1 and newFaceLabel <> F2 and newFaceLabel in Faces(complex) then
-				Error(Concatenation("JoinFaces: Given new face label ", 
-					String(newFaceLabel), " conflicts with existing faces: ", 
-					String(Faces(complex)), "."));
-			fi;
-			if EdgesOfFaces(complex)[F1] <> EdgesOfFaces(complex)[F2] then
-				Error(Concatenation(
-					"JoinFaces: The two given faces are incident to different edges, namely ",
-					String(EdgesOfFaces(complex)[F1]), " and ",
-					String(EdgesOfFaces(complex)[F2]), "."));
-			fi;
+		__SIMPLICIAL_CheckFace(complex, F1, "JoinFaces");
+		__SIMPLICIAL_CheckFace(complex, F2, "JoinFaces");
+		if F1 = F2 and F1 = newFaceLabel then
+			return [complex, newFaceLabel];
+		fi;
+		if newFaceLabel <> F1 and newFaceLabel <> F2 and newFaceLabel in Faces(complex) then
+			Error(Concatenation("JoinFaces: Given new face label ", 
+				String(newFaceLabel), " conflicts with existing faces: ", 
+				String(Faces(complex)), "."));
+		fi;
+		if EdgesOfFaces(complex)[F1] <> EdgesOfFaces(complex)[F2] then
+			Error(Concatenation(
+				"JoinFaces: The two given faces are incident to different edges, namely ",
+				String(EdgesOfFaces(complex)[F1]), " and ",
+				String(EdgesOfFaces(complex)[F2]), "."));
+		fi;
 
-			return JoinFacesNC(complex, F1, F2, newFaceLabel);
+		return JoinFacesNC(complex, F1, F2, newFaceLabel);
 	end
 );
 RedispatchOnCondition( JoinFaces, true, 
@@ -1223,7 +1267,15 @@ InstallOtherMethod(JoinFaces,
 	"for a polygonal complex and a list",
 	[IsPolygonalComplex,IsList],
 	function(complex,faceList)
-		return JoinFaces(complex,faceList,Last(Faces(complex))+1);
+		local faceSet, label;
+		
+		faceSet := Set(faceList);
+		if Length(faceSet) = 1 then
+			label := faceSet[1];
+		else
+			label := Last(Faces(complex))+1;
+		fi;
+		return JoinFaces(complex,faceList,label);
 	end
 );
 RedispatchOnCondition( JoinFaces, true, 
@@ -1234,7 +1286,15 @@ InstallOtherMethod(JoinFacesNC,
 	"for a polygonal complex and a list",
 	[IsPolygonalComplex,IsList],
 	function(complex,faceList)
-		return JoinFacesNC(complex,faceList,Last(Faces(complex))+1);
+		local faceSet, label;
+
+                faceSet := Set(faceList);
+                if Length(faceSet) = 1 then
+                        label := faceSet[1];
+                else
+                        label := Last(Faces(complex))+1;
+                fi;
+                return JoinFacesNC(complex,faceList,label);
 	end
 );
 RedispatchOnCondition( JoinFacesNC, true, 

--- a/unit_tests/Test_BorderCases_PolygonalComplex.g
+++ b/unit_tests/Test_BorderCases_PolygonalComplex.g
@@ -295,19 +295,26 @@ BindGlobal( "__SIMPLICIAL_Test_JoinEdges", function()
  end);
 
 BindGlobal( "__SIMPLICIAL_Test_JoinFaces", function()
-     local oneFace;
+     local s, oneFace;
 
-     oneFace := JoinFaces(JanusHead(),[1,2]);
-     Assert(0,Length(Faces(oneFace[1]))=1);
+     s := JoinFaces(JanusHead(),[1,2]);
+     Assert(0,Length(Faces(s[1]))=1);
 
-     oneFace := JoinFaces(JanusHead(),[1]);
-     Assert(0,oneFace[2]=1);
+     s := JoinFaces(JanusHead(),[1]);
+     Assert(0,s[2]=1);
 
-     oneFace := JoinFaces(JanusHead(),1,1);
-     Assert(0,oneFace[2]=1);
+     s := JoinFaces(JanusHead(),1,1);
+     Assert(0,s[2]=1);
 
-     oneFace := JoinFaces(JanusHead(),1,1,10);
-     Assert(0,oneFace[2]=10);
+     s := JoinFaces(JanusHead(),1,1,10);
+     Assert(0,s[2]=10);
+
+      oneFace:=SimplicialSurfaceByVerticesInFaces([[1,2,3]]);
+      s:=JoinFacesNC(JanusHead(),1,2)[1];
+      Assert(0,IsIsomorphic(oneFace,s));
+
+      s:=JoinFacesNC(JanusHead(),[1,2])[1];
+      Assert(0,IsIsomorphic(oneFace,s));
 end);
 
 BindGlobal( "__SIMPLICIAL_Test_SplitVertex", function()

--- a/unit_tests/Test_BorderCases_PolygonalComplex.g
+++ b/unit_tests/Test_BorderCases_PolygonalComplex.g
@@ -237,7 +237,7 @@ BindGlobal( "__SIMPLICIAL_Test_SplitEdge", function()
 end);
 
 BindGlobal( "__SIMPLICIAL_Test_JoinEdges", function()
-     local eye,closeEye, triple, tripleTogether, tripleDoubleTogether, 
+     local eye, closeEye, closeEye1, closeEye2, triple, tripleTogether, tripleDoubleTogether, 
            falseTriforce, fT1, fT2, fT3, fT4, fT5, fT6, s, s1;
 
      #Test Close Eye
@@ -248,6 +248,15 @@ BindGlobal( "__SIMPLICIAL_Test_JoinEdges", function()
 
       closeEye := JoinEdges( eye, 2, 6 );;
       Assert(0,InnerEdges(closeEye[1])=[7]);
+      
+      closeEye := closeEye[1];
+      closeEye1 := JoinEdges(closeEye,7,7);
+      Assert(0,closeEye1[2]=7);
+      Assert(0,IsIsomorphic(closeEye1[1],closeEye));
+
+      closeEye2 := JoinEdges(closeEye,[7]);
+      Assert(0,closeEye2[2]=7);
+      Assert(0,IsIsomorphic(closeEye2[1],closeEye));
 
       #Test Triple
 
@@ -284,6 +293,22 @@ BindGlobal( "__SIMPLICIAL_Test_JoinEdges", function()
       s1:=JoinEdges(s,[1,4,7]);
       Assert(0,FacesOfEdge(s1[1],10)=[1,2,3]);
  end);
+
+BindGlobal( "__SIMPLICIAL_Test_JoinFaces", function()
+     local oneFace;
+
+     oneFace := JoinFaces(JanusHead(),[1,2]);
+     Assert(0,Length(Faces(oneFace[1]))=1);
+
+     oneFace := JoinFaces(JanusHead(),[1]);
+     Assert(0,oneFace[2]=1);
+
+     oneFace := JoinFaces(JanusHead(),1,1);
+     Assert(0,oneFace[2]=1);
+
+     oneFace := JoinFaces(JanusHead(),1,1,10);
+     Assert(0,oneFace[2]=10);
+end);
 
 BindGlobal( "__SIMPLICIAL_Test_SplitVertex", function()
     local ramSurf,split1,hex,edgeSplit,vertSplit,triangle,split2,fiveGon,split3;

--- a/unit_tests/test_main.g
+++ b/unit_tests/test_main.g
@@ -32,6 +32,7 @@ BindGlobal( "SIMPLICIAL_TestAll", function()
     __SIMPLICIAL_Test_JoinEdges();
     __SIMPLICIAL_Test_SplitVertex();
     __SIMPLICIAL_Test_JoinVertices();
+    __SIMPLICIAL_Test_JoinFaces();
     __SIMPLICIAL_Test_JoinVertexEdgePaths();
     __SIMPLICIAL_Test_SplitVertexEdgePath();
     __SIMPLICIAL_Test_SplitEdgePath();


### PR DESCRIPTION
Issue #79 
I changed the implementation of JoinEdges and JoinFaces so that they are similar to JoinVertices in respect to the cases of two same edges/faces and a list of length 1.